### PR TITLE
Add support for Scala 2.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 /.metals
+/.idea/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Flexible Octopus Model
-
+ [ ![Download](https://api.bintray.com/packages/guardian/editorial-tools/flexible-octopus-model/images/download.svg) ](https://bintray.com/guardian/editorial-tools/flexible-octopus-model/_latestVersion) 
+ 
 This is the Thrift definition of the Flexible Octopus model.
 
 This repo uses the [sbt-bintray](https://github.com/sbt/sbt-bintray) plugin for publishing to Bintray.

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,9 @@
 
 name             := "flexible-octopus-model"
 scalaVersion     := "2.13.2"
-version          := "0.2.0"
+version          := "0.3.0"
 organization     := "com.gu"
+crossScalaVersions := Seq("2.11.12", "2.13.1")
 
 resolvers += Resolver.jcenterRepo
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
To allow us to use the model in flexible-content, we need to provide support for Scala 2.11.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
It's possible to import and use the fleixible-octopus-model Scala library in the flexible-content project.