### PR TITLE
Adds the lastModifiedBy field to the Article struct

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 
 name             := "flexible-octopus-model"
 scalaVersion     := "2.13.2"
-version          := "0.3.0"
+version          := "0.4.0"
 organization     := "com.gu"
 crossScalaVersions := Seq("2.11.12", "2.13.1")
 

--- a/src/main/thrift/octopus.thrift
+++ b/src/main/thrift/octopus.thrift
@@ -88,4 +88,7 @@ struct Article {
 
     // file name including suffix, a composite of story_group, object type and object number
     8: required string filename;
+
+    // the last user who updated the article
+    9: required string lastModifiedBy
 }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
In [Workflow](https://github.com/guardian/workflow-frontend/), we want to be able to display pieces of additional print information: the status of the body text and the last user who modified it. We already have a `status` value on the `Article` struct, but don't have a current representation of the last user who modified the `Article`. This PR adds that value.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
I've marked the new field as `required` on the assumption that when content is created in InCopy the value `last_user` is assigned at the first point the content is saved. Currently, we don't receive updates from Octopus when content is _initially_ created in InCopy, but after a version is saved, so I don't believe it would be possible for us to receive an Octopus update that has no relevant value for `lastModifiedBy`.