### PR TITLE
Add support for Scala 2.12.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
 
 name             := "flexible-octopus-model"
 scalaVersion     := "2.13.2"
-version          := "0.4.0"
+version          := "0.5.0"
 organization     := "com.gu"
-crossScalaVersions := Seq("2.11.12", "2.13.1")
+crossScalaVersions := Seq("2.11.12", "2.12.11", "2.13.1")
 
 resolvers += Resolver.jcenterRepo
 


### PR DESCRIPTION
## What does this change?
To allow us to use the model in `workflow` and `workflow-frontend`, we need to provide support Scala 2.12.11.

## How to test
n/a

## How can we measure success?
n/a

## Have we considered potential risks?
n/a

## Images
n/a
