### PR TITLE
Correct sonatype release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
 # Flexible Octopus Model
  
 This is the Thrift definition of the Flexible Octopus model.
+
+### Testing Locally
+
+If you need to try out your changes with consumer applications (e.g. `flexible-octopus-converter`) then...
+
+- Run `+publishLocal` in sbt (note the `+` makes it cross-compile, e.g. `flexible-octopus-converter` consumes the 2.13 version)
+- Update the version in the consumer application(s) (e.g. https://github.com/guardian/flexible-octopus-converter/blob/2a479b8a782d306b1cebbc1abaec49c2c95844ba/build.sbt#L34) using the `-SNAPSHOT` version.
+
+### Publishing a new version
+
+1. Follow the instructions for [publishing a new version to Maven Central via Sonatype](https://docs.google.com/document/d/1rNXjoZDqZMsQblOVXPAIIOMWuwUKe3KzTCttuqS7AcY/edit#).
+   This will include (if not already completed for another project):
+    - Creating and publishing a PGP key
+    - Setting up an account on Sonatype and having it added to the `com.gu` group
+    - Storing your Sonatype credentials in your global sbt configuration
+2. Ensure you're on the branch which holds the changes you're ready to release and that these changes have been approved & tested with the application(s) which use this library (using the `-SNAPSHOT` version).
+3. Ensure the project still builds with `sbt compile`
+4. Run `sbt release`. You will be prompted for a 'release version' – which you should set following semantic versioning as either a patch,
+   minor or major version bump. You will also be prompted for a 'next version' – which should be a patch version ahead of your release version
+   and end `-SNAPSHOT`. `version.sbt` will be updated to reflect this 'next version'.

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,10 @@
+import ReleaseTransformations._
 
 name             := "flexible-octopus-model"
 scalaVersion     := "2.13.2"
 organization     := "com.gu"
-crossScalaVersions := Seq("2.11.12", "2.12.11", "2.13.1")
+crossScalaVersions := Seq("2.11.12", "2.12.11", scalaVersion.value)
+releaseCrossBuild := true
 
 resolvers += Resolver.jcenterRepo
 
@@ -14,9 +16,22 @@ homepage := scmInfo.value.map(_.browseUrl)
 developers := List(Developer(id = "guardian", name = "Guardian", email = null, url = url("https://github.com/guardian")))
 
 releasePublishArtifactsAction := PgpKeys.publishSigned.value
-publishTo := sonatypePublishToBundle.value
-releaseProcess += releaseStepCommandAndRemaining("sonatypeRelease")
+publishTo := sonatypePublishTo.value
 
+releaseProcess := Seq[ReleaseStep](
+  checkSnapshotDependencies,
+  inquireVersions,
+  runClean,
+  runTest,
+  setReleaseVersion,
+  publishArtifacts,
+  releaseStepCommand("sonatypeReleaseAll"),
+  commitReleaseVersion,
+  tagRelease,
+  setNextVersion,
+  commitNextVersion,
+  pushChanges
+)
 
 libraryDependencies ++= Seq(
   "org.apache.thrift" % "libthrift" % "0.13.0",

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.0"
+version in ThisBuild := "0.5.1-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.0-SNAPSHOT"
+version in ThisBuild := "0.5.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "0.5.0-SNAPSHOT"


### PR DESCRIPTION
Some tweaks following #7 given learnings from https://github.com/guardian/flexible-model/pull/37...

- notably replacing `publishTo := sonatypePublishToBundle.value` with `publishTo := sonatypePublishTo.value` (as the former staged artifacts to local machine causing the release to fail silently with `warn [SonatypeService] No staging repository is found. Do publishSigned first.`
- also improved the README
- also made the steps of the release process explicit and moved the git interactions to after the publish/release step so that if something goes wrong there's not annoying git cleanup to do
