### PR TITLE
remove bintray resolver

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,8 +6,6 @@ organization     := "com.gu"
 crossScalaVersions := Seq("2.11.12", "2.12.11", scalaVersion.value)
 releaseCrossBuild := true
 
-resolvers += Resolver.jcenterRepo
-
 licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 publishArtifact := true
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Removes unused external resolvers as they may pose a security risk, specifically the [MavenGate supply chain attack](https://blog.oversecured.com/Introducing-MavenGate-a-supply-chain-attack-method-for-Java-and-Android-applications/)

## How to test

`sbt clean compile` should be enough, we just need to see all the dependencies are being pulled down
