### PR TITLE
Adopt GHA Scala Library Release Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+on:
+  workflow_dispatch:
+  pull_request:
+
+  # triggering CI on default branch improves caching
+  # see https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: corretto
+          java-version: 11 # Although we may release a Java 8-compatible artifact, avoid running EOL'd Java 8 if we can
+          cache: sbt
+      - name: Build (there are currently no tests)
+        run: sbt -v +compile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,13 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@main
+    permissions: { contents: write, pull-requests: write }
+    secrets:
+      SONATYPE_PASSWORD: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD }}
+      PGP_PRIVATE_KEY: ${{ secrets.AUTOMATED_MAVEN_RELEASE_PGP_SECRET }}
+      GITHUB_APP_PRIVATE_KEY: ${{ secrets.AUTOMATED_MAVEN_RELEASE_GITHUB_APP_PRIVATE_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 /.metals
 /.idea/
+.bsp/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Flexible Octopus Model
- 
+
+[![flexible-octopus-model Scala version support](https://index.scala-lang.org/guardian/flexible-octopus-model/flexible-octopus-model/latest-by-scala-version.svg?platform=jvm)](https://index.scala-lang.org/guardian/flexible-octopus-model/flexible-octopus-model)
+
 This is the Thrift definition of the Flexible Octopus model.
 
 ### Testing Locally
@@ -9,15 +11,8 @@ If you need to try out your changes with consumer applications (e.g. `flexible-o
 - Run `+publishLocal` in sbt (note the `+` makes it cross-compile, e.g. `flexible-octopus-converter` consumes the 2.13 version)
 - Update the version in the consumer application(s) (e.g. https://github.com/guardian/flexible-octopus-converter/blob/2a479b8a782d306b1cebbc1abaec49c2c95844ba/build.sbt#L34) using the `-SNAPSHOT` version.
 
-### Publishing a new version
+# Publishing a new release
 
-1. Follow the instructions for [publishing a new version to Maven Central via Sonatype](https://docs.google.com/document/d/1rNXjoZDqZMsQblOVXPAIIOMWuwUKe3KzTCttuqS7AcY/edit#).
-   This will include (if not already completed for another project):
-    - Creating and publishing a PGP key
-    - Setting up an account on Sonatype and having it added to the `com.gu` group
-    - Storing your Sonatype credentials in your global sbt configuration
-2. Ensure you're on the branch which holds the changes you're ready to release and that these changes have been approved & tested with the application(s) which use this library (using the `-SNAPSHOT` version).
-3. Ensure the project still builds with `sbt compile`
-4. Run `sbt release`. You will be prompted for a 'release version' – which you should set following semantic versioning as either a patch,
-   minor or major version bump. You will also be prompted for a 'next version' – which should be a patch version ahead of your release version
-   and end `-SNAPSHOT`. `version.sbt` will be updated to reflect this 'next version'.
+This repo uses [`gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow)
+to automate publishing releases (both full & preview releases) - see
+[**Making a Release**](https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/making-a-release.md).

--- a/build.sbt
+++ b/build.sbt
@@ -1,34 +1,26 @@
-import ReleaseTransformations._
+import ReleaseTransformations.*
+import sbtversionpolicy.withsbtrelease.ReleaseVersion
 
 name             := "flexible-octopus-model"
-scalaVersion     := "2.13.2"
+scalaVersion     := "2.13.13"
 organization     := "com.gu"
-crossScalaVersions := Seq("2.11.12", "2.12.11", scalaVersion.value)
+crossScalaVersions := Seq("2.12.19", scalaVersion.value)
+scalacOptions := Seq("-release:8") // https://github.com/guardian/flexible-octopus-converter currently uses Java 8 for CI
+
+licenses := Seq(License.Apache2)
+
+releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value
 releaseCrossBuild := true
-
-licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html"))
-publishArtifact := true
-
-scmInfo := Some(ScmInfo(url("https://github.com/guardian/flexible-octopus-model"), "scm:git@github.com:guardian/flexible-octopus-model"))
-homepage := scmInfo.value.map(_.browseUrl)
-developers := List(Developer(id = "guardian", name = "Guardian", email = null, url = url("https://github.com/guardian")))
-
-releasePublishArtifactsAction := PgpKeys.publishSigned.value
-publishTo := sonatypePublishTo.value
-
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,
   runClean,
   runTest,
   setReleaseVersion,
-  publishArtifacts,
-  releaseStepCommand("sonatypeReleaseAll"),
   commitReleaseVersion,
   tagRelease,
   setNextVersion,
-  commitNextVersion,
-  pushChanges
+  commitNextVersion
 )
 
 libraryDependencies ++= Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.10
+sbt.version=1.9.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,4 @@
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "20.5.0")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.4")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
-
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.4.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")
+addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.0")

--- a/project/version.sbt
+++ b/project/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "0.5.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.1-SNAPSHOT"
+ThisBuild / version := "0.5.1-SNAPSHOT"


### PR DESCRIPTION
This replaces the old release process which had developers manually running `sbt release` on their own laptops - each developer had to obtain their own PGP key and Sonatype credentials, which was an elaborate & fiddly process.

This PR adopts [`gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow), which provides an automated release process that uses single shared set of release credentials, available through GitHub Organisation Secrets (like we already do with NPM) - this workflow allows you to [release a new library version](https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/making-a-release.md) with the click of a button!

Most of the changes made here are documented in `gha-scala-library-release-workflow`'s [configuration.md](https://github.com/guardian/gha-scala-library-release-workflow/blob/add-configuration-guidence/docs/configuration.md).