### PR TITLE
Upgrade thrift to address high vulnerability.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,6 @@ releaseProcess := Seq[ReleaseStep](
 )
 
 libraryDependencies ++= Seq(
-  "org.apache.thrift" % "libthrift" % "0.13.0",
+  "org.apache.thrift" % "libthrift" % "0.23.0",
   "com.twitter" %% "scrooge-core" % "20.5.0"
 )


### PR DESCRIPTION
Addresses this vulnerability:

<img width="955" height="234" alt="Screenshot 2026-06-04 at 16 58 09" src="https://github.com/user-attachments/assets/7f0cfe23-b773-4294-8d18-fae24eabc0ff" />

It has been tested locally in workflow.